### PR TITLE
Regulations 2025 marius

### DIFF
--- a/source/content/dynamic_events.tex
+++ b/source/content/dynamic_events.tex
@@ -1,9 +1,9 @@
 \chapter{Dynamic Events}
 
 During the dynamic events, the actual performance of the automated model
-vehicles will be challenged in two different disciplines (Free Drive and
-Parking, Obstacle Evasion Course). Parking maneuvers are performed in a
-distinctive parking zone following the starting line during the “Free Drive”
+vehicles will be challenged in two different disciplines (Free Drive, Obstacle 
+Evasion Course). Parking maneuvers are performed in a distinctive parking zone 
+following the starting line during the \HighlightChange{“Obstacle Evasion Course”}
 discipline. The additional elements of the “Obstacle Evasion Course” combine
 the rural road scenario with challenges of suburban scenarios.
 

--- a/source/content/dynamic_events.tex
+++ b/source/content/dynamic_events.tex
@@ -3,7 +3,7 @@
 During the dynamic events, the actual performance of the automated model
 vehicles will be challenged in two different disciplines (Free Drive, Obstacle 
 Evasion Course). Parking maneuvers are performed in a distinctive parking zone 
-following the starting line during the \HighlightChange{“Obstacle Evasion Course”}
+following the starting line during the \HighlightNew{“Obstacle Evasion Course”}
 discipline. The additional elements of the “Obstacle Evasion Course” combine
 the rural road scenario with challenges of suburban scenarios.
 

--- a/source/content/dynamic_events.tex
+++ b/source/content/dynamic_events.tex
@@ -3,7 +3,7 @@
 During the dynamic events, the actual performance of the automated model
 vehicles will be challenged in two different disciplines (Free Drive, Obstacle 
 Evasion Course). Parking maneuvers are performed in a distinctive parking zone 
-following the starting line during the \HighlightNew{“Obstacle Evasion Course”}
+following the \HighlightNew{parking traffic sign} during the \HighlightNew{“Obstacle Evasion Course”}
 discipline. The additional elements of the “Obstacle Evasion Course” combine
 the rural road scenario with challenges of suburban scenarios.
 

--- a/source/content/freedrive_course.tex
+++ b/source/content/freedrive_course.tex
@@ -1,71 +1,18 @@
-\section{Free Drive (w/o Obstacles) and Parking}
+\section{Free Drive (w/o Obstacles)}
 
 In this event, the vehicle shall automatically cover the farthest possible
-distance in a given time. The vehicle drives in the right lane. Additionally,
-the vehicle can perform automatic parking maneuver by finding a suitable
-parking spot inside a parking lot.
+distance in a given time. The vehicle drives in the right lane.
 
 \subsection{Scenario}
 
 The complexity of this scenario is limited. It consists of a road with two
 parallel lanes - one for each driving direction. This scenario shall imitate a
 rural road environment, consisting of long straight sections, tight turns,
-intersections, side road junctions and also containing a parking lot. The lanes
+intersections, side road junctions. The lanes
 are limited by different types of lane markings. All markings are white and
 approx. 18 mm to 20 mm wide, if not specified differently. The starting line (a
-checkered line of approx. 50 mm) marks the beginning of the track, which is the
-parking zone (cf. Section \ref{fig_parking_lot}).
+checkered line of approx. 50 mm) marks the beginning of the track.
 
-\subsubsection{Parking Lot}
-
-Following the starting line and indicated by a traffic sign, there are parking
-areas containing spots for parking in parallel and perpendicular orientation to
-the track within the next 20 m. The parking zone is a planar and straight part
-of the track with a dashed center line without missing lane markings.
-Additional elements (intersections, missing lane markings, traffic signs, etc.)
-are not present. All areas for parking are located in this zone.
-
-\subsubsection{Parallel Parking}
-
-Within the parking zone there is at least one parallel parking area next to the
-right lane. White cardboard boxes represent other vehicles. The boxes can be
-fixed to the ground. There is a space of 20 mm to 200 mm between the right lane
-marking and the side of the obstacle which faces the track. The obstacles
-measure at least 100 mm in height and length. The parking area and the track
-are located in the same ground plane. Individual parking spots of the parking
-area can be marked as no parking zones. These areas may not be used for
-parking, but may be used for maneuvering.
-
-There will be multiple parking spots of different size in the parallel parking
-area(s) next to the track. The left- and right-hand limits of the parking spots
-are defined by the right lane marking and an additional solid white line (also
-18 mm to 20 mm wide). Front and rear limits are defined either by white
-cardboard boxes or by a no parking zone (cf. Section
-\ref{fig_parallel_parking}). Approaching from the starting line, the parking
-spots will be growing in length. The final and largest spot will beat least 700
-mm in length. Nevertheless, small distances of under 400 mm might be present
-between obstacles anywhere inside the parallel parking area(s).
-
-\subsubsection{Perpendicular Parking}
-
-An additional type of parking area within the parking zone consists of several
-parking spots with a perpendicular orientation to the track. Such area is
-located at least once on the left-hand side of the track and may also be used
-for parking.
-
-All spots have the same size, as shown in Section
-\ref{fig_perpendicular_parking}. The parking spots are separated and limited to
-the front as well as to the rear by 18 mm to 20 mm wide white markings. Parking
-spots can be blocked by obstacles or no parking zones. A parking spot is
-considered to be blocked, if the vehicle cannot be placed completely inside the
-spot. Obstacles possess the same dimensions as in the parallel parking area and
-can be placed at a distance of 20 mm to 100 mm from the solid left lane
-marking.
-
-For parking, the vehicle must be positioned inside one marked spot that is not
-blocked. Vehicles may move forward or backward into the parking space. The left
-lane of the track may only be crossed during the actual parking maneuver. When
-searching for a parking spot, the vehicle must continue to use the right lane.
 
 \subsubsection{Lane width}
 
@@ -120,7 +67,7 @@ regulations concerning the right of way are to be ignored.
 \subsubsection{Traffic Signs}
 \label{traffic_signs}
 
-In addition to the parking sign at the starting line and the steep hill signs
+In addition to the the steep hill signs
 described above, other supporting traffic signs can be present on the roadside.
 
 Guide signs will be used to indicate sharp turns. They mark a curved section of
@@ -182,31 +129,7 @@ Section \ref{rc_mode}.
 
 \subsection{Parking}
 
-Parking can be performed in any of the rounds of the Free Drive event.
-Successful parking maneuvers result in multipliers to the overall distance
-covered. Collisions during parking attempts result in penalties. The best
-parking results will be considered in the final score (i.e. additional parking
-maneuvers can eliminate penalties of other parking attempts).
-
-After each passing of the starting line, the vehicle can perform one parking
-attempt by finding a parking spot within the parking areas and maneuver into
-it, without touching the surrounding obstacles. The start of the parking
-maneuver has to be signaled using the turn indicators. After the vehicle came
-to a complete stop and flashed all turn indicators at least one time, signaling
-a successful parking maneuver, it may drive on. The correct position of the
-vehicle will be checked from both sides of the track with the first flashing of
-the indicators. Penalties may apply until the vehicle is driving with a
-positive speed along the route while touching the right lane with at least 3
-wheels.
-
-A complete parking maneuver requires the vehicle to come to a full stop being
-located in a valid spot with at least three of its wheels and flash all turn
-indicators at least one time. While maneuvering out of the parking spot, the
-vehicle may cross the left lane, but has to continue driving in the right lane.
-
-Leaving the outer boundaries of the parking area is penalized the same as
-leaving the right lane while driving. The speed in the parking lot is not
-limited, especially not after the parking maneuver has been completed.
+\HighlightChange{Parking has been removed from the Freedrive Course and moved to the Obstacle Evasion Course.}
 
 \subsection{Scoring}
 \label{freedrive_scoring}
@@ -250,7 +173,6 @@ Each team starts this event with a multiplier of \textbf{1.0}.
 		\textbf{Triggering Event}         & \textbf{Maximum Count} & \textbf{Multiplier Modification} \\ \midrule
 		Canceled attempt / second attempt & 1                      & -0.3                             \\
 		WiFi enabled during competition   & 1                      & -0.5                             \\
-		Complete parking maneuver         & 2                      & +1.0                             \\
 		\bottomrule
 	\end{tabular}
 \end{table}

--- a/source/content/freedrive_course.tex
+++ b/source/content/freedrive_course.tex
@@ -129,7 +129,7 @@ Section \ref{rc_mode}.
 
 \subsection{Parking}
 
-\HighlightChange{Parking has been removed from the Freedrive Course and moved to the Obstacle Evasion Course.}
+\HighlightNew{Parking has been removed from the Freedrive Course and moved to the Obstacle Evasion Course.}
 
 \subsection{Scoring}
 \label{freedrive_scoring}

--- a/source/content/obstacle_course.tex
+++ b/source/content/obstacle_course.tex
@@ -19,9 +19,7 @@ The suburban area is a special section of the track, containing additional
 elements compared to the track design of the rural road scenario. Beginning and
 end of suburban areas are defined by markings on the road surface (cf. Section
 \ref{fig_road_markings}) and according traffic signs (cf. Section
-\ref{traffic_signs}). \HighlightChange{The suburban area containins a parking lot as well as the starting line (a 
-checkered line of approx. 50 mm) which marks the beginning of the track, which is the
-parking zone.} (cf. Section \ref{fig_parking_lot})
+\ref{traffic_signs}). \HighlightChange{The suburban area containins a parking lot which is indicated by the parking traffic sign.} (cf. Section \ref{fig_parking_lot})
 
 The speed limit within the suburban section, as indicated by the traffic signs
 has to be scaled by 1:10 (i.e. a speed limit of 30 km/h corresponds to 0.83
@@ -143,7 +141,7 @@ specifications.
 
 \subsubsection{\HighlightChange{Parking Lot}}
 
-Following the starting line and indicated by a traffic sign, there are parking
+\HighlightChange{Indicated by a traffic sign}, there are parking
 areas containing spots for parking in parallel and perpendicular orientation to
 the track within the next 20 m. The parking zone is a planar and straight part
 of the track with a dashed center line without missing lane markings.
@@ -166,8 +164,8 @@ area(s) next to the track. The left- and right-hand limits of the parking spots
 are defined by the right lane marking and an additional solid white line (also
 18 mm to 20 mm wide). Front and rear limits are defined either by white
 cardboard boxes or by a no parking zone (cf. Section
-\ref{fig_parallel_parking}). Approaching from the starting line, the parking
-spots will be growing in length. The final and largest spot will beat least 700
+\ref{fig_parallel_parking}). \HighlightChange{Approaching from the parking sign, the parking
+spots will be growing in length.} The final and largest spot will beat least 700
 mm in length. Nevertheless, small distances of under 400 mm might be present
 between obstacles anywhere inside the parallel parking area(s).
 
@@ -329,9 +327,10 @@ Section \ref{rc_mode}.
 \HighlightChange{Parking can be performed in any of the rounds of the Obstacle Evasion Course.
 Collisions during parking attempts result in penalties.}
 
-After each passing of the starting line, the vehicle performs \HighlightChange{exactly one} parking
+\HighlightChange{Within each round}, the vehicle performs \HighlightChange{maximum one} parking
 attempt by finding a parking spot within the parking areas and maneuver into
-it, without touching the surrounding obstacles. The start of the parking
+it, without touching the surrounding obstacles. \HighlightChange{More than one one parking attempt per round will result in penalties.} \HighlightChange{The Parking spots are indicated by the parking sign.
+(Note: Unlike the in the previous regulations, the starting line does not indiciate parking.)} The start of the parking
 maneuver has to be signaled using the turn indicators \HighlightChange{(into the direction of the parking lot)}. 
 After the vehicle came
 to a complete stop and flashed all turn indicators at least one time, signaling
@@ -493,10 +492,10 @@ to the speed on the road next to the parking lot.}
 			\textbf{Positive}                                           & \textbf{Neutral}                                                  & \textbf{Negative}          \\
 			\midrule
 			Vehicle parked correctly in the parking lot                 & Not parked correctly                                              & Collision with an Obstacle \\
-			All of the wheels are within the boundaries of the parking spot& No parking maneuver performed                                  &                            \\
+			All of the wheels are within the boundaries of the parking spot& No or more than one parking maneuver performed                                  &                            \\
 			Correct use of turn indicators                              & Wrong use of turn indicators                                      &                            \\
 			\topstrut
-			\textbf{+30}                                                & \textbf{0}                                                        & \textbf{-10}               \\
+			\textbf{+20}                                                & \textbf{0}                                                        & \textbf{-10}               \\
 			\bottomrule
 		\end{tabularx}
 	\end{table}

--- a/source/content/obstacle_course.tex
+++ b/source/content/obstacle_course.tex
@@ -4,9 +4,9 @@
 
 The event “Obstacle Evasion Course” extends the track of the Free Drive event
 with additional elements which need to be considered during the driving task.
-Static and dynamic obstacles are added to the rural road scenario. 
-\HighlightChange{Additionally, the vehicle has to perform automatic parking maneuvers 
-by finding a suitable parking spot inside a parking lot.} The track does additionally
+Static and dynamic obstacles are added to the rural road scenario.
+\HighlightNew{Additionally, the vehicle has to perform automatic parking maneuvers
+	by finding a suitable parking spot inside a parking lot.} The track does additionally
 contain at least one suburban section at this point. All definitions concerning
 the course of the road maintain validity. There will be at least 1000 mm track
 length between obstacles. The additional elements are spaced at least 1000 mm
@@ -19,7 +19,7 @@ The suburban area is a special section of the track, containing additional
 elements compared to the track design of the rural road scenario. Beginning and
 end of suburban areas are defined by markings on the road surface (cf. Section
 \ref{fig_road_markings}) and according traffic signs (cf. Section
-\ref{traffic_signs}). \HighlightChange{The suburban area containins a parking lot which is indicated by the parking traffic sign.} (cf. Section \ref{fig_parking_lot})
+\ref{traffic_signs}). \HighlightNew{The suburban area containins a parking lot which is indicated by the parking traffic sign.} (cf. Section \ref{fig_parking_lot})
 
 The speed limit within the suburban section, as indicated by the traffic signs
 has to be scaled by 1:10 (i.e. a speed limit of 30 km/h corresponds to 0.83
@@ -139,16 +139,16 @@ not have the same distance to the corresponding element as the traffic sign
 (cf. Section \ref{turning}). See the following sections for the according
 specifications.
 
-\subsubsection{\HighlightChange{Parking Lot}}
+\subsubsection{\HighlightNew{Parking Lot}}
 
-\HighlightChange{Indicated by a traffic sign}, there are parking
+\HighlightNew{Indicated by a traffic sign}, there are parking
 areas containing spots for parking in parallel and perpendicular orientation to
 the track within the next 20 m. The parking zone is a planar and straight part
 of the track with a dashed center line without missing lane markings.
 Additional elements (intersections, missing lane markings, traffic signs, etc.)
 are not present. All areas for parking are located in this zone.
 
-\subsubsection{\HighlightChange{Parallel Parking}}
+\subsubsection{\HighlightNew{Parallel Parking}}
 
 Within the parking zone there is at least one parallel parking area next to the
 right lane. White cardboard boxes represent other vehicles. The boxes can be
@@ -164,12 +164,12 @@ area(s) next to the track. The left- and right-hand limits of the parking spots
 are defined by the right lane marking and an additional solid white line (also
 18 mm to 20 mm wide). Front and rear limits are defined either by white
 cardboard boxes or by a no parking zone (cf. Section
-\ref{fig_parallel_parking}). \HighlightChange{Approaching from the parking sign, the parking
-spots will be growing in length.} The final and largest spot will beat least 700
+\ref{fig_parallel_parking}). \HighlightNew{Approaching from the parking sign, the parking
+	spots will be growing in length.} The final and largest spot will beat least 700
 mm in length. Nevertheless, small distances of under 400 mm might be present
 between obstacles anywhere inside the parallel parking area(s).
 
-\subsubsection{\HighlightChange{Perpendicular Parking}}
+\subsubsection{\HighlightNew{Perpendicular Parking}}
 
 An additional type of parking area within the parking zone consists of several
 parking spots with a perpendicular orientation to the track. Such area is
@@ -324,14 +324,14 @@ Section \ref{rc_mode}.
 
 \subsection{Parking}
 
-\HighlightChange{Parking can be performed in any of the rounds of the Obstacle Evasion Course.
-Collisions during parking attempts result in penalties.}
+\HighlightNew{Parking can be performed in any of the rounds of the Obstacle Evasion Course.
+	Collisions during parking attempts result in penalties.}
 
-\HighlightChange{Within each round}, the vehicle performs \HighlightChange{maximum one} parking
+\HighlightNew{Within each round}, the vehicle performs \HighlightNew{maximum one} parking
 attempt by finding a parking spot within the parking areas and maneuver into
-it, without touching the surrounding obstacles. \HighlightChange{More than one one parking attempt per round will result in penalties.} \HighlightChange{The Parking spots are indicated by the parking sign.
-(Note: Unlike the in the previous regulations, the starting line does not indiciate parking.)} The start of the parking
-maneuver has to be signaled using the turn indicators \HighlightChange{(into the direction of the parking lot)}. 
+it, without touching the surrounding obstacles. \HighlightNew{More than one one parking attempt per round will result in penalties.} \HighlightNew{The Parking spots are indicated by the parking sign.
+	(Note: Unlike the in the previous regulations, the starting line does not indiciate parking.)} The start of the parking
+maneuver has to be signaled using the turn indicators \HighlightNew{(into the direction of the parking lot)}.
 After the vehicle came
 to a complete stop and flashed all turn indicators at least one time, signaling
 a successful parking maneuver, it may drive on. The correct position of the
@@ -341,14 +341,14 @@ positive speed along the route while touching the right lane with at least 3
 wheels.
 
 A complete parking maneuver requires the vehicle to come to a full stop being
-located in a valid spot \HighlightChange{with all of its wheels} and flash all turn
+located in a valid spot \HighlightNew{with all of its wheels} and flash all turn
 indicators at least one time. While maneuvering out of the parking spot, the
 vehicle may cross the left lane, but has to continue driving in the right lane
 after the parking maneuver.
 
 Leaving the outer boundaries of the parking area is penalized the same as
-leaving the right lane while driving. \HighlightChange{The speed in the parking lot is limited
-to the speed on the road next to the parking lot.}
+leaving the right lane while driving. \HighlightNew{The speed in the parking lot is limited
+	to the speed on the road next to the parking lot.}
 
 \subsection{Scoring}{
 	\label{obstacle_scoring}
@@ -484,18 +484,18 @@ to the speed on the road next to the parking lot.}
 
 	\clearpage
 
-	
-	\subsubsection*{\HighlightChange{Parking}}
+
+	\subsubsection*{\HighlightNew{Parking}}
 	\begin{table}[H]
 		\begin{tabularx}{\textwidth}{XXX}
 			\toprule
-			\textbf{Positive}                                           & \textbf{Neutral}                                                  & \textbf{Negative}          \\
+			\textbf{Positive}                                               & \textbf{Neutral}                               & \textbf{Negative}          \\
 			\midrule
-			Vehicle parked correctly in the parking lot                 & Not parked correctly                                              & Collision with an Obstacle \\
-			All of the wheels are within the boundaries of the parking spot& No or more than one parking maneuver performed                                  &                            \\
-			Correct use of turn indicators                              & Wrong use of turn indicators                                      &                            \\
+			Vehicle parked correctly in the parking lot                     & Not parked correctly                           & Collision with an Obstacle \\
+			All of the wheels are within the boundaries of the parking spot & No or more than one parking maneuver performed &                            \\
+			Correct use of turn indicators                                  & Wrong use of turn indicators                   &                            \\
 			\topstrut
-			\textbf{+20}                                                & \textbf{0}                                                        & \textbf{-10}               \\
+			\textbf{+20}                                                    & \textbf{0}                                     & \textbf{-10}               \\
 			\bottomrule
 		\end{tabularx}
 	\end{table}

--- a/source/content/obstacle_course.tex
+++ b/source/content/obstacle_course.tex
@@ -4,8 +4,9 @@
 
 The event “Obstacle Evasion Course” extends the track of the Free Drive event
 with additional elements which need to be considered during the driving task.
-Parking maneuvers shall not be performed within this event. Static and dynamic
-obstacles are added to the rural road scenario. The track does additionally
+Static and dynamic obstacles are added to the rural road scenario. 
+\HighlightChange{Additionally, the vehicle has to perform automatic parking maneuvers 
+by finding a suitable parking spot inside a parking lot.} The track does additionally
 contain at least one suburban section at this point. All definitions concerning
 the course of the road maintain validity. There will be at least 1000 mm track
 length between obstacles. The additional elements are spaced at least 1000 mm
@@ -18,7 +19,9 @@ The suburban area is a special section of the track, containing additional
 elements compared to the track design of the rural road scenario. Beginning and
 end of suburban areas are defined by markings on the road surface (cf. Section
 \ref{fig_road_markings}) and according traffic signs (cf. Section
-\ref{traffic_signs}).
+\ref{traffic_signs}). \HighlightChange{The suburban area containins a parking lot as well as the starting line (a 
+checkered line of approx. 50 mm) which marks the beginning of the track, which is the
+parking zone.} (cf. Section \ref{fig_parking_lot})
 
 The speed limit within the suburban section, as indicated by the traffic signs
 has to be scaled by 1:10 (i.e. a speed limit of 30 km/h corresponds to 0.83
@@ -137,6 +140,57 @@ complemented with specific markings on the road surface. Those markings must
 not have the same distance to the corresponding element as the traffic sign
 (cf. Section \ref{turning}). See the following sections for the according
 specifications.
+
+\subsubsection{\HighlightChange{Parking Lot}}
+
+Following the starting line and indicated by a traffic sign, there are parking
+areas containing spots for parking in parallel and perpendicular orientation to
+the track within the next 20 m. The parking zone is a planar and straight part
+of the track with a dashed center line without missing lane markings.
+Additional elements (intersections, missing lane markings, traffic signs, etc.)
+are not present. All areas for parking are located in this zone.
+
+\subsubsection{\HighlightChange{Parallel Parking}}
+
+Within the parking zone there is at least one parallel parking area next to the
+right lane. White cardboard boxes represent other vehicles. The boxes can be
+fixed to the ground. There is a space of 20 mm to 200 mm between the right lane
+marking and the side of the obstacle which faces the track. The obstacles
+measure at least 100 mm in height and length. The parking area and the track
+are located in the same ground plane. Individual parking spots of the parking
+area can be marked as no parking zones. These areas may not be used for
+parking, but may be used for maneuvering.
+
+There will be multiple parking spots of different size in the parallel parking
+area(s) next to the track. The left- and right-hand limits of the parking spots
+are defined by the right lane marking and an additional solid white line (also
+18 mm to 20 mm wide). Front and rear limits are defined either by white
+cardboard boxes or by a no parking zone (cf. Section
+\ref{fig_parallel_parking}). Approaching from the starting line, the parking
+spots will be growing in length. The final and largest spot will beat least 700
+mm in length. Nevertheless, small distances of under 400 mm might be present
+between obstacles anywhere inside the parallel parking area(s).
+
+\subsubsection{\HighlightChange{Perpendicular Parking}}
+
+An additional type of parking area within the parking zone consists of several
+parking spots with a perpendicular orientation to the track. Such area is
+located at least once on the left-hand side of the track and may also be used
+for parking.
+
+All spots have the same size, as shown in Section
+\ref{fig_perpendicular_parking}. The parking spots are separated and limited to
+the front as well as to the rear by 18 mm to 20 mm wide white markings. Parking
+spots can be blocked by obstacles or no parking zones. A parking spot is
+considered to be blocked, if the vehicle cannot be placed completely inside the
+spot. Obstacles possess the same dimensions as in the parallel parking area and
+can be placed at a distance of 20 mm to 100 mm from the solid left lane
+marking.
+
+For parking, the vehicle must be positioned inside one marked spot that is not
+blocked. Vehicles may move forward or backward into the parking space. The left
+lane of the track may only be crossed during the actual parking maneuver. When
+searching for a parking spot, the vehicle must continue to use the right lane.
 
 \subsubsection{Barred Area}
 
@@ -269,6 +323,33 @@ skipping challenges of the obstacle course (by not driving in the right lane)
 will be punished with the penalty designated for the respective element. Each
 activation of RC-mode is penalized. RC-mode is subject to the regulations in
 Section \ref{rc_mode}.
+
+\subsection{Parking}
+
+\HighlightChange{Parking can be performed in any of the rounds of the Obstacle Evasion Course.
+Collisions during parking attempts result in penalties.}
+
+After each passing of the starting line, the vehicle performs \HighlightChange{exactly one} parking
+attempt by finding a parking spot within the parking areas and maneuver into
+it, without touching the surrounding obstacles. The start of the parking
+maneuver has to be signaled using the turn indicators \HighlightChange{(into the direction of the parking lot)}. 
+After the vehicle came
+to a complete stop and flashed all turn indicators at least one time, signaling
+a successful parking maneuver, it may drive on. The correct position of the
+vehicle will be checked from both sides of the track with the first flashing of
+the indicators. Penalties may apply until the vehicle is driving with a
+positive speed along the route while touching the right lane with at least 3
+wheels.
+
+A complete parking maneuver requires the vehicle to come to a full stop being
+located in a valid spot \HighlightChange{with all of its wheels} and flash all turn
+indicators at least one time. While maneuvering out of the parking spot, the
+vehicle may cross the left lane, but has to continue driving in the right lane
+after the parking maneuver.
+
+Leaving the outer boundaries of the parking area is penalized the same as
+leaving the right lane while driving. \HighlightChange{The speed in the parking lot is limited
+to the speed on the road next to the parking lot.}
 
 \subsection{Scoring}{
 	\label{obstacle_scoring}
@@ -403,6 +484,22 @@ Section \ref{rc_mode}.
 	\end{table}
 
 	\clearpage
+
+	
+	\subsubsection*{\HighlightChange{Parking}}
+	\begin{table}[H]
+		\begin{tabularx}{\textwidth}{XXX}
+			\toprule
+			\textbf{Positive}                                           & \textbf{Neutral}                                                  & \textbf{Negative}          \\
+			\midrule
+			Vehicle parked correctly in the parking lot                 & Vehicle parked correctly in the parking lot                       & Collision with an Obstacle \\
+			All of the wheels are within the boundaries of the parking spot& Wheels touch the boundary of the parking spot                     & At least one wheel is outside the boundary of the parking spot  \\
+			Correct use of turn indicators                              & Wrong use of turn indicators                                      & No parking maneuver performed\\
+			\topstrut
+			\textbf{+30}                                                & \textbf{0}                                                        & \textbf{-15}               \\
+			\bottomrule
+		\end{tabularx}
+	\end{table}
 
 	\subsubsection*{Barred Area}
 	\begin{table}[H]

--- a/source/content/obstacle_course.tex
+++ b/source/content/obstacle_course.tex
@@ -492,11 +492,11 @@ to the speed on the road next to the parking lot.}
 			\toprule
 			\textbf{Positive}                                           & \textbf{Neutral}                                                  & \textbf{Negative}          \\
 			\midrule
-			Vehicle parked correctly in the parking lot                 & Vehicle parked correctly in the parking lot                       & Collision with an Obstacle \\
-			All of the wheels are within the boundaries of the parking spot& Wheels touch the boundary of the parking spot                     & At least one wheel is outside the boundary of the parking spot  \\
-			Correct use of turn indicators                              & Wrong use of turn indicators                                      & No parking maneuver performed\\
+			Vehicle parked correctly in the parking lot                 & Not parked correctly                                              & Collision with an Obstacle \\
+			All of the wheels are within the boundaries of the parking spot& No parking maneuver performed                                  &                            \\
+			Correct use of turn indicators                              & Wrong use of turn indicators                                      &                            \\
 			\topstrut
-			\textbf{+30}                                                & \textbf{0}                                                        & \textbf{-15}               \\
+			\textbf{+30}                                                & \textbf{0}                                                        & \textbf{-10}               \\
 			\bottomrule
 		\end{tabularx}
 	\end{table}

--- a/source/content/overview.tex
+++ b/source/content/overview.tex
@@ -33,7 +33,7 @@ The maximum amount of points is distributed to the different events as follows:
 \begin{table}[h]
 	\begin{tabular}{|l|l|}
 		\hline
-		Free Drive and Parking:  & 300 points \\ \hline
+		Free Drive:  & 300 points \\ \hline
 		Obstacle Evasion Course: & 400 points \\ \hline\hline
 		Maximum Total Score:     & 700 points \\ \hline
 	\end{tabular}


### PR DESCRIPTION
Moved parking from freedrive to obstacle evasion course.

**Changelog:**
_overview.tex_
Removed 'and parking' from freedrive in scoring table.

_dynamic_events.tex_
Removed Parking from Free Drive & Parking
Exchanged Free Drive with Obstacle Evasion Course

_obstacle_course.tex_
Added note about parking in introduction of OEC.
Added note about parking lot in suburban scenario.
Copied sections Parking Lot, Parallel Parking and Perpendicular Parking from FD to OEC.
Copied Parking section from Freedrive to OEC.
Parking lot is indicated by parking traffic sign, not starting line.
Exactly one parking attempt per round, otherwise neutral scoring.
Indicator lights in direction of parking lot.
All wheels in the spot.
Parking speed is speed of street next to parking.
Added scoring table for parking.

_freedrive_course.tex_
Removed 'and Parking' from title.
Removed parking from the introduction.
Removed parking lot and parking zone from scenario.
Removed subsubsections about Parking Lot, Parallel Parking and Perpendicular Parking.
Removed parking sign from the traffic signs.
Modified parking subsection to indicate that parking has been moved to the obstacle evasion course.
Removed parking multiplier.